### PR TITLE
Second Vouch instance is cold standby

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ adjusting the `{1..10}` for the range you want to have in the file.
 
 ## Architecture; redundancy and slashing considerations
 
-2 Vouch (one warm standby) and a 3/5 Dirk (3 threshold, 5 total) were chosen carefully. With 2 Vouch and 2/4 Dirk there
+2 Vouch (one cold standby) and a 3/5 Dirk (3 threshold, 5 total) were chosen carefully. With 2 Vouch and 2/4 Dirk there
 would be a risk of slashing; 3 Vouch and 3/5 Dirk, Vouch might not get to threshold and never be able to sign duties. 
 
 1 Vouch and 2/3 Dirk would also work just as well.


### PR DESCRIPTION
Clarifies that second Vouch instance is a cold standby and must not be running as it can cause primary Vouch instance to not reach signature threshold (3/5) if a single dirk instance is not available. In addition, since only primary instance is able to propose builder blocks, the secondary instance could interfere with the proposal even if all 5 dirks instances are online and lead to proposing a local block instead.